### PR TITLE
Added libxmu-dev to dependencies

### DIFF
--- a/README
+++ b/README
@@ -27,7 +27,7 @@ NOTE: I only tested the build process under Ubuntu 10.04, if there are any issue
 
 List of packages needed for compilation on Ubuntu:
 
-build-essential g++ cmake libx11-dev freeglut3-dev libglu1-mesa-dev libxcb1-dev libxext-dev libxxf86vm-dev libxi-dev glew-utils libglew1.5-dev
+build-essential g++ cmake libx11-dev freeglut3-dev libglu1-mesa-dev libxcb1-dev libxext-dev libxxf86vm-dev libxi-dev libxmu-dev glew-utils libglew1.5-dev
 
 To compile and install GLTools:
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ COMPILATION AND INSTALLATION
 
 List of packages needed for compilation on Ubuntu:
 
-    build-essential g++ cmake libx11-dev freeglut3-dev libglu1-mesa-dev libxcb1-dev libxext-dev libxxf86vm-dev libxi-dev glew-utils libglew1.5-dev
+    build-essential g++ cmake libx11-dev freeglut3-dev libglu1-mesa-dev libxcb1-dev libxext-dev libxxf86vm-dev libxi-dev libxmu-dev glew-utils libglew1.5-dev
 
 To compile and install GLTools:
 


### PR DESCRIPTION
Would not compile on Ubuntu 10.10 without libxmu-dev. Added libxmu-dev to dependencies to resolve this issue.
